### PR TITLE
Email with CSV metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ Here's an example email I made:
 
 <img width="556" height="815" alt="image" src="https://github.com/user-attachments/assets/8c6caeae-efb9-494f-a650-325b50fba067" />
 
+## Custom Metadata using CSV
+
+You can use personalized data from a CSV instead of the database. This is useful when you need to send to an arbitrary list or include per-recipient information or values.
+
+Flags involved:
+- `--csv_input <CSV>` — load recipients and metadata from a CSV file path
+- `--first-name` — enable first-name replacement in `description` (replaces `{{first_name}}` with the first name of the recipient).
+        *Note that the csv metadata parser uses str.format (i.e., "{row_name}" instead of "{{row_name}}") and is different in format from the first_name replacement logic.
+
+Example of how personalization works in CSV mode:
+- The script replaces `{{first_name}}` in `description` with the `first_name` value or `there` if missing (when `--first-name` is provided).
+- It then formats the `description` with all CSV fields using `desc.format(**meta_data)`, so placeholders like `{reimburse_amt}` will be replaced.
+- The CSV must include an `email` column. This is enforced and the script will error if missing.
+- All `{placeholder}` tokens present in your template `description` must exist as columns in the CSV. If any are missing, the script will stop and list the missing columns.
+- If your CSV contains extra columns that are not referenced by the template (excluding `email` and `first_name`), the script will show a one-time warning listing the unused columns and prompt: "Are you sure you want to continue? (y/n)".
+ **It is important to name the CSV columns exactly as the placeholders in the description.**
+
+
+
 
 # Updating
 

--- a/send_emails.py
+++ b/send_emails.py
@@ -1,6 +1,9 @@
 import os
 import argparse
 import sys
+import pandas as pd
+import re
+from typing import List
 
 # add project root to path (one level up from this file)
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -92,10 +95,16 @@ if __name__ == "__main__":
         action="store_true",
         help="Continue sending emails even if an error occurs."
     )
+    parser.add_argument(
+        "--csv_input",
+        dest="csv_input_path",
+        metavar="CSV",
+        help="Path to a CSV file containing the arguments to pass to the email template."
+    )
     
     args = parser.parse_args()
 
-    recipients = get_recipients(args)
+    
     email_template = emails.templates.get_template(args.template)
     build_args_template = emails.sender.read_json(args.input)
 
@@ -104,26 +113,85 @@ if __name__ == "__main__":
 
     desc_template = build_args_template.get("description", "")
 
-    for to_email, first_name in recipients:
-        desc = desc_template
-        if args.first_name:
-            desc = desc.replace("{{first_name}}", first_name or "there")
+    sent_count = 0
 
-        # per-recipient copy
-        build_args = {**build_args_template, "description": desc}
+    if args.csv_input:
+        print('Reading CSV input...')
+        df = pd.read_csv(args.csv_input_path)
 
-        emails.sender.send_email(
-            email_template=email_template,
-            build_args=build_args,
-            from_email=from_email,
-            to_email=to_email,
-            subject=subject,
-            silent=args.silent,
-            ignore_exceptions=args.ignore_exceptions
+        # using regex to get all placeholders ({row_name}) but exclude double braces ({{first_name}})
+        placeholder_pattern = r'(?<!\{)\{([a-zA-Z_][a-zA-Z0-9_]*)\}(?!\})'
+        placeholders = set(re.findall(placeholder_pattern, desc_template))
+        csv_columns = set(df.columns)
+
+        # Required CSV column for addressing
+        assert 'email' in csv_columns, "CSV is missing required column 'email'."
+
+        missing = placeholders - csv_columns
+        assert not missing, (
+            "CSV is missing columns for template placeholders: "
+            + ", ".join(sorted(missing))
         )
-        
+
+        # Warn if there are unused CSV columns (excluding commonly used identity fields)
+        unused = csv_columns - placeholders - {'email', 'first_name'}
+        if unused:
+            answer = input(
+                f"Warning: The following CSV columns are not used in the template: {sorted(unused)}. "
+                "Are you sure you want to continue? (y/n) "
+            ).strip().lower()
+            if answer != 'y':
+                print('Aborting.')
+                sys.exit(0)
+
+        _meta_datas: List[dict] = df.to_dict(orient='records')
+
+        for meta_data in _meta_datas:
+            desc: str = desc_template
+            if args.first_name:
+                # Replace first name placeholder first
+                desc = desc.replace("{{first_name}}", (meta_data.get('first_name') or "there"))
+            # Always format with CSV fields
+            desc = desc.format(**meta_data)
+
+            # per-recipient copy
+            build_args = {**build_args_template, "description": desc}
+            emails.sender.send_email(
+                email_template=email_template,
+                build_args=build_args,
+                from_email=from_email,
+                to_email=meta_data['email'],
+                subject=subject,
+                silent=args.silent,
+                ignore_exceptions=args.ignore_exceptions
+            )
+            sent_count += 1
+    else:
+        print('Loading database data...')
+        recipients = get_recipients(args)
+
+        #! For backwards compatibility only, new metadata should use the CSV path above
+        for to_email, first_name in recipients:
+            desc = desc_template
+            if args.first_name:
+                desc = desc.replace("{{first_name}}", first_name or "there")
+
+            # per-recipient copy
+            build_args = {**build_args_template, "description": desc}
+
+            emails.sender.send_email(
+                email_template=email_template,
+                build_args=build_args,
+                from_email=from_email,
+                to_email=to_email,
+                subject=subject,
+                silent=args.silent,
+                ignore_exceptions=args.ignore_exceptions
+            )
+            sent_count += 1
+
     if not args.silent:
-        print(f"Done! Sent {len(recipients)} emails.")
+        print(f"Done! Sent {sent_count} emails.")
 
 
 


### PR DESCRIPTION

## Custom Metadata using CSV

You can use personalized data from a CSV instead of the database. This is useful when you need to send to an arbitrary list or include per-recipient information or values.

Flags involved:
- `--csv_input <CSV>` — load recipients and metadata from a CSV file path
- `--first-name` — enable first-name replacement in `description` (replaces `{{first_name}}` with the first name of the recipient).
        *Note that the csv metadata parser uses str.format (i.e., "{row_name}" instead of "{{row_name}}") and is different in format from the first_name replacement logic.

Example of how personalization works in CSV mode:
- The script replaces `{{first_name}}` in `description` with the `first_name` value or `there` if missing (when `--first-name` is provided).
- It then formats the `description` with all CSV fields using `desc.format(**meta_data)`, so placeholders like `{reimburse_amt}` will be replaced.
- The CSV must include an `email` column. This is enforced and the script will error if missing.
- All `{placeholder}` tokens present in your template `description` must exist as columns in the CSV. If any are missing, the script will stop and list the missing columns.
- If your CSV contains extra columns that are not referenced by the template (excluding `email` and `first_name`), the script will show a one-time warning listing the unused columns and prompt: "Are you sure you want to continue? (y/n)".
 **It is important to name the CSV columns exactly as the placeholders in the description.**

